### PR TITLE
Create HW0-dockerscrshot

### DIFF
--- a/HW0-dockerscrshot
+++ b/HW0-dockerscrshot
@@ -1,0 +1,2 @@
+CONTAINER ID   IMAGE         COMMAND    CREATED          STATUS                      PORTS     NAMES
+4873663f1181   hello-world   "/hello"   2 minutes ago    Exited (0) 2 minutes ago              gallant_williams


### PR DESCRIPTION
Added the output I received after running docker ps -a. I used "docker ps -a" because the container had already stopped running so it was not showing up when I ran "docker ps"